### PR TITLE
Include <numeric> header in rl_utils.cpp

### DIFF
--- a/src/rl_utils.cpp
+++ b/src/rl_utils.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <cassert>
 #include <sstream>
+#include <numeric>
 
 #include "mersenne_twister.hpp"
 


### PR DESCRIPTION
std::accumulate is in the <numeric> header. Doesn't compile on Debian testing without this include, with this change it does.
