### PR TITLE
Added missing "numeric" header

### DIFF
--- a/src/rl_utils.cpp
+++ b/src/rl_utils.cpp
@@ -1,5 +1,6 @@
 #include "rl_utils.hpp"
 
+#include <numeric>
 #include <algorithm>
 #include <vector>
 #include <cassert>


### PR DESCRIPTION
Hey,

Just noticed infra arcana didn't build on my system (archlinux, g++ version 6.1.1) because of a missing header. Specifically this was due to the use of `std::accumulate`. This should fix the problem.
