### PR TITLE
include <numeric> for std::accumulate in random.cpp

### DIFF
--- a/include/rl_utils.hpp
+++ b/include/rl_utils.hpp
@@ -82,6 +82,7 @@ void assert_impl(const bool check,
 #include <string>
 #include <iostream>
 #include <algorithm>
+#include <numeric>
 
 // This header must be supplied by the "user" project, and contain some
 // necessary symbols such as "map_w" and "map_h".


### PR DESCRIPTION
On OS X El Capitan I got the following error when building ia:
rl_utils/src/random.cpp:130:26: error: no member named 'accumulate' in namespace
      'std'
    const int sum = std::accumulate(begin(weights), end(weights), 0);

Looks like #include <numeric> was accidentally dropped in recent refactoring and breaking up of various files, which is needed for std::accumulate. Added it back which lets the build succeed.
